### PR TITLE
Raise exception if no default

### DIFF
--- a/DictDots.py
+++ b/DictDots.py
@@ -13,15 +13,18 @@ class DictDots:
 
     @staticmethod
     def get(data, query, default=None):
-        """
-
+        """Get a specific nested value.
+        
         Args:
             data (dict):
             query (str):
             default:
+                If not set, get returns an error
 
         Returns:
-
+        
+        Raises:
+            Exception: Raised if no item was found and no default was provided.
         """
         if not DictDots.is_valid_query(query):
             raise InvalidQueryString
@@ -34,8 +37,10 @@ class DictDots:
                 key = int(key)
             if key in current_data:
                 current_data = current_data[key]
-            else:
+            elif default:
                 return default
+            else:
+                raise Exception(f"Dictionary has no key matching query: '{query}'")
 
         return current_data
 


### PR DESCRIPTION
`get` should raise an error if there is no item matching query to pattern match off of other projects like django.