### PR TITLE
#2: DictDots.filter()

### DIFF
--- a/dd_types.py
+++ b/dd_types.py
@@ -17,3 +17,6 @@ DotCurrentKey = Union[str, int]
 
 """A type representing the accepted data types for getter functions."""
 DotCurrentData = DotSearchable
+
+"""The result of a filter query. Can be empty."""
+DotFilterResult = List[Any]

--- a/docs/ddql.md
+++ b/docs/ddql.md
@@ -1,11 +1,13 @@
 # Potential data language
 
+---
 This is a wishlist of how I want the query language to look.
 The only things on here that work right now are `get s` and `get ns`.
 
 I haven't yet decided if I actually want to support sets due to how
 the indexing works through a hash. It would be cumbersome to try and
 pass a big value into dictdots in the query string. 
+
 ## Get
 
 Get returns a specific object matching an exact query.

--- a/tests/test_dict_dots.py
+++ b/tests/test_dict_dots.py
@@ -12,7 +12,7 @@ from dd_exceptions import InvalidQueryString, DoesNotExist
 ])
 def test_is_valid_query(query, result):
     """Test that queries can be validated."""
-    assert DictDots.is_valid_query(query) == result
+    assert DictDots.is_valid_get_query(query) == result
 
 
 @pytest.mark.parametrize("data,expected", [


### PR DESCRIPTION
- Begin work for adding the `filter` function to search for lists of matching keys in a dict.

Issue: https://github.com/alexlambson/python-dict-dots/issues/2