### PR TITLE
#6: Adds `exists`

### DIFF
--- a/dictdots/__init__.py
+++ b/dictdots/__init__.py
@@ -108,5 +108,41 @@ class DictDots:
 
         return current_data
 
+    @classmethod
+    def exists(cls, searchable: DotSearchable, query: DotQuery) -> bool:
+        """Check to see if a key exists.
+
+        Args:
+            searchable (DotSearchable):
+            query (DotQuery):
+
+        Returns (bool):
+            ``True`` if the key exists, regardless of value.
+        """
+        DictDots._validate_get(searchable, query)
+        keys = query.split('.')
+        # current_searchable is the searchable we are currently digging into.
+        current_searchable = searchable
+
+        type_methods = {
+            dict: cls._dict_getter,
+            list: cls._list_getter,
+        }
+
+        for key in keys:
+            if key.isnumeric():
+                # We don't support numerical strings for now, so convert them to ints.
+                key = int(key)
+
+            method = type_methods[type(current_searchable)]
+
+            try:
+                current_searchable = method(key, current_searchable)
+            except KeyNotFound:
+                return False
+
+        # Key exists if we make it through all the fot-notated keys without a KeyNotFound error.
+        return True
+
 
 

--- a/dictdots/tests/test_dict_dots.py
+++ b/dictdots/tests/test_dict_dots.py
@@ -133,3 +133,45 @@ def test_get__raises_does_not_exist(query):
     data = {"hello": "world"}
     with pytest.raises(DoesNotExist):
         DictDots.get(data, query)
+
+
+@pytest.mark.parametrize("key,expected", [
+    ("covenant", False),
+    ("unsc.army.noble.n6", True),
+    ("forerunner.warrior_servants.nice", True),
+    ("covenant.banished.atriox", False),
+    ("unsc", True),
+    ("forerunner.warrior_servants.metarch_03", True),
+])
+def test_exists(key, expected):
+    """Tests that ``exists`` correctly returns ``True`` when a key exists, regardless of value."""
+    t = {
+        "unsc": {
+            "oni": {
+                "director": "Parangosky",
+                "section_3": {
+                    "scientist": "Halsey"
+                }
+            },
+            "army": {
+                "noble": {
+                    "commander": "Holland",
+                    "n1": "MIA",
+                    "n2": "MIA",
+                    "n3": "MIA",
+                    "n4": "MIA",
+                    "n5": "MIA",
+                    "n6": None
+                }
+            }
+        },
+        "forerunner": {
+            "warrior_servants": {
+                "metarch_01": "Mendicant Bias",
+                "metarch_02": "Offensive Bias",
+                "metarch_03": "",
+                "nice": False,
+            }
+        },
+    }
+    assert DictDots.exists(t, key) == expected

--- a/docs/ddql.md
+++ b/docs/ddql.md
@@ -5,8 +5,11 @@ The only things on here that work right now are `get s` and `get ns`.
 
 I haven't yet decided if I actually want to support sets due to how
 the indexing works through a hash. It would be cumbersome to try and
-pass a big value into dictdots in the query string. 
+pass a big value into dictdots in the query string.
+
 ## Get
+
+---
 
 Get returns a specific object matching an exact query.
 
@@ -45,6 +48,8 @@ Get returns a specific object matching an exact query.
 
 ## Filter
 
+---
+
 Filter returns a list of objects that matched the query 
 and an empty list if there were no matches.
 
@@ -79,3 +84,28 @@ Supports all `get` query args.
         {"the fall of": "reach"},
     }
     ```
+
+## Exists
+
+---
+
+Uses the same logic as `get`, but returns a boolean instead of the value.
+Checks if the key exists rather than grabbing the value.
+
+Must still return `True` even if the value is falsey. 
+
+e.g. 
+
+```python
+bob = {
+    "sierra_117": False,
+    "sandtrap": "",
+    "endless": None,
+}
+
+assert DictDots.exists(bob, "sierra_117")
+assert DictDots.exists(bob, "sandtrap")
+assert DictDots.exists(bob, "endless")
+```
+
+should all pass.


### PR DESCRIPTION
Creates the `exists` function and adds tests.

It is currently WET (why extra typing?) and needs to be DRY'd up from `get`.

Issue: https://github.com/alexlambson/python-dict-dots/issues/6